### PR TITLE
[feat] 웹뷰 뒤로가기 및 외부 링크 처리 추가(#13)

### DIFF
--- a/app/src/main/java/com/example/dangbun/MainActivity.kt
+++ b/app/src/main/java/com/example/dangbun/MainActivity.kt
@@ -15,7 +15,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            DangbunWebViewScreen()
+            DangbunWebViewScreen(onClose = { finish() })
         }
     }
 }
@@ -34,5 +34,5 @@ fun greeting(
 @Preview(showBackground = true)
 @Composable
 fun greetingPreview() {
-    DangbunWebViewScreen()
+    DangbunWebViewScreen(onClose = { })
 }

--- a/app/src/main/java/com/example/dangbun/ui/webview/DangbunWebViewScreen.kt
+++ b/app/src/main/java/com/example/dangbun/ui/webview/DangbunWebViewScreen.kt
@@ -1,23 +1,75 @@
 package com.example.dangbun.ui.webview
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
-fun DangbunWebViewScreen(url: String = "https://dangbun-frontend-virid.vercel.app/") {
-    AndroidView(
-        factory = { context ->
+fun DangbunWebViewScreen(
+    url: String = "https://dangbun-frontend-virid.vercel.app/",
+    onClose: () -> Unit,
+) {
+    // 환경 객체 가져오기
+    val context = LocalContext.current
+
+    // WebView에 대한 기록 남겨두도록
+    val webView =
+        remember {
             WebView(context).apply {
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
-
-                webViewClient = WebViewClient()
+                webViewClient =
+                    object : WebViewClient() {
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView,
+                            url: String,
+                        ): Boolean {
+                            return handleUrl(context, url)
+                        }
+                    }
                 loadUrl(url)
             }
-        },
+        }
+
+    BackHandler {
+        if (webView.canGoBack()) {
+            webView.goBack()
+        } else {
+            // 뒤로 갈 페이지가 없으면 WebView 화면을 닫는 동작을 실행
+            onClose()
+        }
+    }
+
+    AndroidView(
+        factory = { webView },
     )
+}
+
+private fun handleUrl(
+    context: android.content.Context,
+    url: String,
+): Boolean {
+    // http/https는 WebView가 계속 로드하도록 false
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return false
+    }
+
+    // 그 외 스킴(tel:, mailto:, intent: 등)은 외부 앱으로 위임
+    return try {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        context.startActivity(intent)
+        true
+    } catch (e: ActivityNotFoundException) {
+        // 처리할 앱이 없다면 WebView가 처리하도록 넘김(또는 true로 막기)
+        false
+    }
 }


### PR DESCRIPTION
## 🧩 관련 Issue
Closes #13 

---

## 🎯 작업 개요
Android WebView에서 뒤로가기 동작을 웹 히스토리 기준으로 처리하고, tel/mailto/intent 등 외부 링크를 앱(Intent)으로 위임하도록 개선

---

## 🔍 상세 내용
- WebView 인스턴스를 remember로 유지하여 히스토리(뒤로가기) 상태를 보존합니다.
- 뒤로가기 처리:
  - WebView 히스토리가 있으면 `goBack()`
  - 히스토리가 없으면 `onClose()` 실행
- 외부 링크 처리:
  - http/https는 WebView 내부 로딩
  - 그 외 스킴(tel:, mailto:, intent:)은 외부 앱으로 위임(Intent)

---

## ✅ 완료 조건
- [x] 웹 페이지 이동 후 뒤로가기가 정상 동작한다
- [x] 외부 스킴 링크가 있을 경우 앱이 튕기지 않고 처리된다
- [x] ktlintCheck가 통과한다
- [x] 코드 리뷰 완료

---

## 👤 담당자
- @chohs4164
