### PR TITLE
[feat] 온보딩 화면의 상단 여백 조정(#27)

### DIFF
--- a/app/src/main/java/com/example/dangbun/MainActivity.kt
+++ b/app/src/main/java/com/example/dangbun/MainActivity.kt
@@ -15,7 +15,11 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            DangbunWebViewScreen(onClose = { finish() })
+            DangbunWebViewScreen(
+                url = "https://dangbun-frontend-virid.vercel.app/onboarding",
+                onClose = { finish() },
+                applyStatusBarPadding = true
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/dangbun/ui/webview/DangbunWebViewScreen.kt
+++ b/app/src/main/java/com/example/dangbun/ui/webview/DangbunWebViewScreen.kt
@@ -14,10 +14,13 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 
 private const val TAG = "DANGBUN_WV"
@@ -33,6 +36,7 @@ private const val TARGET_SCALE = 0.8f
 fun DangbunWebViewScreen(
     url: String = "https://dangbun-frontend-virid.vercel.app/",
     onClose: () -> Unit,
+    applyStatusBarPadding: Boolean = false,
 ) {
     val context = LocalContext.current
 
@@ -82,6 +86,10 @@ fun DangbunWebViewScreen(
                     super.onPageFinished(view, url)
                     view.post { view.scrollTo(0, 0) }
 
+                    // ✅ 온보딩: 위로 붙는 현상 완화 (상단 여백)
+                    if (applyStatusBarPadding) {
+                        injectOnboardingTopInsetFix(view, topPx = 24)
+                    }
                     // ✅ 공통 픽스 (모달 등)
                     injectCommonFixes(view)
                     // ✅ 스플래시 픽스
@@ -123,10 +131,21 @@ fun DangbunWebViewScreen(
         if (webView.canGoBack()) webView.goBack() else onClose()
     }
 
+    val webViewModifier =
+        if (applyStatusBarPadding) {
+            Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .padding(top = 20.dp)
+        } else {
+            Modifier.fillMaxSize()
+        }
+
     AndroidView(
-        modifier = Modifier.fillMaxSize(),
+        modifier = webViewModifier,
         factory = { webView }
     )
+
 }
 
 private fun handleUrl(

--- a/app/src/main/java/com/example/dangbun/ui/webview/WebViewFixes.kt
+++ b/app/src/main/java/com/example/dangbun/ui/webview/WebViewFixes.kt
@@ -5,7 +5,13 @@ import com.example.dangbun.ui.webview.fixes.addplace.AddPlaceMemberSelectFix
 import com.example.dangbun.ui.webview.fixes.common.CommonModalFix
 import com.example.dangbun.ui.webview.fixes.kakao.KakaoFix
 import com.example.dangbun.ui.webview.fixes.myplace.MyPlaceFix
+import com.example.dangbun.ui.webview.fixes.onboarding.OnboardingTopInsetFix
 import com.example.dangbun.ui.webview.fixes.splash.SplashFix
+
+// ✅ 온보딩(상단 여백 내려오기) 픽스
+internal fun injectOnboardingTopInsetFix(view: WebView, topPx: Int = 24) {
+    OnboardingTopInsetFix.inject(view, topPx)
+}
 
 internal fun injectMyPlaceUnifiedFix(view: WebView) {
     MyPlaceFix.inject(view)

--- a/app/src/main/java/com/example/dangbun/ui/webview/fixes/onboarding/OnboardingTopInsetFix.kt
+++ b/app/src/main/java/com/example/dangbun/ui/webview/fixes/onboarding/OnboardingTopInsetFix.kt
@@ -1,0 +1,45 @@
+package com.example.dangbun.ui.webview.fixes.onboarding
+
+import android.webkit.WebView
+
+internal object OnboardingTopInsetFix {
+    internal fun inject(view: WebView, topPx: Int = 180) {
+        view.evaluateJavascript(provideJs(topPx), null)
+    }
+
+    private fun provideJs(topPx: Int): String {
+        return """
+        (function() {
+          try {
+            var styleId = '__db_onboarding_top_inset_fix__';
+            var style = document.getElementById(styleId);
+            if (!style) {
+              style = document.createElement('style');
+              style.id = styleId;
+              document.head.appendChild(style);
+            }
+
+            // ✅ 전체 화면이 위로 붙는 현상 완화: 상단 여백 추가
+            style.innerHTML = `
+              html, body {
+                box-sizing: border-box !important;
+              }
+
+              body {
+                padding-top: ${'$'}{topPx}px !important;
+              }
+
+              main, #root, #__next {
+                position: relative !important;
+                top: ${'$'}{topPx}px !important;
+              }
+
+            `;
+
+          } catch(e) {
+            console.log('ONBOARDING_TOP_INSET_FIX_ERR', e && e.message);
+          }
+        })();
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
## 🧩 관련 Issue
Closes #27

---

## 🎯 작업 개요
모바일 환경에서 어플 실행 시 온보딩 화면이 상단으로 치우쳐보이는 문제 발생

---

## 🔍 상세 내용
- 모바일 환경에서 앱 실행 시 온보딩 화면의 상단 여백이 부족하여 화면이 잘리는 문제가 발생하여 상단 여백 추가로 화면 이용에 문제가 없도록 조정
---

## ✅ 완료 조건
- [x] 웹 페이지 이동 후 뒤로가기가 정상 동작한다
- [x] 상단 여백이 충분하여 화면을 이용하는데에 문제가 없다
- [x] ktlintCheck가 통과한다
- [x] 코드 리뷰 완료

---

## 👤 담당자
- @chohs4164
